### PR TITLE
Filtrer les propriétaires par commune 

### DIFF
--- a/cadastre/cadastre_dialogs.py
+++ b/cadastre/cadastre_dialogs.py
@@ -930,6 +930,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         self.btSelectionnerLieu.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'select.png')))
         self.btExportProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'releve.png')))
         self.btExportParcelleProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'releve.png')))
+        self.btResetCommuneProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'delete.png')))
         self.btResetProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'delete.png')))
         self.btResetParcelleProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'delete.png')))
         self.btCentrerProprietaire.setIcon(QIcon(os.path.join(plugin_dir, 'forms', 'icons', 'centrer.png')))
@@ -1078,6 +1079,27 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 'chosenFeature': None,
                 'connector': None,
                 'resetWidget': self.btResetParcelleProprietaire
+            },
+            'commune_proprietaire': {
+                'widget': self.liCommuneProprietaire,
+                'labelAttribute': 'tex2',
+                'table': 'geo_commune',
+                'geomCol': 'geom',
+                'sql': '',
+                'layer': None,
+                'request': None,
+                'attributes': ['ogc_fid', 'tex2', 'idu', 'geo_commune', 'geom', 'lot'],
+                'orderBy': ['tex2'],
+                'features': None,
+                'chosenFeature': None,
+                'resetWidget': self.btResetCommuneProprietaire,
+                'children': [
+                    {
+                        'key': 'section',
+                        'fkey': 'geo_commune',
+                        'getIfNoFeature': True
+                    }
+                ]
             }
         }
 
@@ -1169,6 +1191,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         # setup some gui items
         self.setupSearchCombobox('commune', None, 'sql')
+        self.setupSearchCombobox('commune_proprietaire', None, 'sql')
         # self.setupSearchCombobox('section', None, 'sql')
 
         # Check majic content
@@ -1245,7 +1268,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         if not self.hasMajicDataProp:
             self.qc.updateLog(
                 u"<b>Pas de données MAJIC propriétaires</b> -> désactivation de la recherche de propriétaires")
-
+       
     def setupSearchCombobox(self, combo, filterExpression=None, queryMode='qgis'):
         """
         Fil given combobox with data
@@ -1271,7 +1294,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         self.searchComboBoxes[combo]['layer'] = layer
         if layer:
-
+            
             # Get all features
             keepattributes = self.searchComboBoxes[combo]['attributes']
             request = QgsFeatureRequest().setSubsetOfAttributes(

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -219,7 +219,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="3">
+             <item row="1" column="3">
               <widget class="QToolButton" name="btExportProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé de propriété</string>

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -229,8 +229,9 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
-              <widget class="QComboBox" name="liParcelleProprietaire">
+             <!--Combo-->
+             <item row="0" column="1">
+              <widget class="QComboBox" name="liCommuneProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -242,7 +243,7 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
+             <item row="1" column="1">
               <widget class="QComboBox" name="liProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -255,7 +256,35 @@
                </property>
               </widget>
              </item>
+             <item row="2" column="1">
+              <widget class="QComboBox" name="liParcelleProprietaire">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <!--Labels-->
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="text">
+                <string>Commune</string>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="0">
+              <widget class="QLabel" name="label_4">
+               <property name="text">
+                <string>Nom</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
               <widget class="QLabel" name="label_3">
                <property name="maximumSize">
                 <size>
@@ -268,14 +297,8 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>Nom</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="3">
+            <!--Export Buttons-->
+             <item row="2" column="3">
               <widget class="QToolButton" name="btExportParcelleProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé parcellaire</string>
@@ -285,7 +308,18 @@
                </property>
               </widget>
              </item>
+             <!--Reset Buttons-->
              <item row="0" column="2">
+              <widget class="QToolButton" name="btResetCommuneProprietaire">
+               <property name="toolTip">
+                <string>Retour à l'ensemble des communes</string>
+               </property>
+               <property name="text">
+                <string>...</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
               <widget class="QToolButton" name="btResetProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>
@@ -295,7 +329,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
+             <item row="2" column="2">
               <widget class="QToolButton" name="btResetParcelleProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>
@@ -387,10 +421,12 @@ p, li { white-space: pre-wrap; }
   <tabstop>btCentrerLieu</tabstop>
   <tabstop>btZoomerLieu</tabstop>
   <tabstop>btSelectionnerLieu</tabstop>
+  <tabstop>liCommuneProprietaire</tabstop>
   <tabstop>liProprietaire</tabstop>
   <tabstop>liParcelleProprietaire</tabstop>
   <tabstop>btResetProprietaire</tabstop>
   <tabstop>btExportProprietaire</tabstop>
+  <tabstop>btResetCommuneProprietaire</tabstop>
   <tabstop>btResetParcelleProprietaire</tabstop>
   <tabstop>btExportParcelleProprietaire</tabstop>
   <tabstop>btCentrerProprietaire</tabstop>


### PR DESCRIPTION
En correspondance avec l'issue 3liz/QgisCadastrePlugin#260.

### Comportement

L'utilisateur sélectionne une Commune (paramètre optionnel). Lorsque l'utilisateur commence à écrire dans le champ `Nom`, la recherche sera réalisée sur les propriétaire de la commune sélectionnée.

SI aucune commune n'est sélectionnée, alors la recherche porte sur tous les propriétaire de la table `proprietaire` avec le fonctionnement natif du plugin.

Le comportement est ici identique au fonctionnement entre le filtre `Commune `et `Adresse `de la Recherche de lieux.

### Détails techniques

Lors de la saisie d'un nom, le plugin lance une requête SQL dans la table 'proprietaire'.
https://github.com/3liz/QgisCadastrePlugin/blob/6441a4ba90f2d424d16055a3654612735bc83227/cadastre/cadastre_dialogs.py#L1435

Ce sont les résultats de cette recherche qui sont listés lors d'une saisie.

La modification consiste à réaliser une jointure sur le champ `ccocom` du type seulement si une valeur a été sélectionnée dans le la liste du filtre `Commune  `: 

`sql+= " INNER JOIN commune c ON c.ccocom = p.ccocom"`


### Rendu graphique

![image](https://user-images.githubusercontent.com/16317988/95753867-85906480-0ca2-11eb-8ba7-6264e73ac192.png)


### Contraintes

Pour la création du filtre `Commune`, nous avons repris la table `geo_commune` comme pour le filtre Commune de la recherche de lieu, puisque l'initialisation des combobox (= liste) se réalise via une couche chargée dans la portée du plugin (accessible et chargée dans Qgis).
